### PR TITLE
Stop the player at screen boundaries

### DIFF
--- a/objects/obj_player/Keyboard_37.gml
+++ b/objects/obj_player/Keyboard_37.gml
@@ -1,1 +1,3 @@
-x = x - 4;
+if (x - sprite_width >= 0) then {
+	x = x - 4;
+}

--- a/objects/obj_player/Keyboard_39.gml
+++ b/objects/obj_player/Keyboard_39.gml
@@ -1,1 +1,3 @@
-x = x + 4;
+if (x + sprite_width <= room_width) then {
+	x = x + 4;
+}


### PR DESCRIPTION
This PR make the player stop at a resonable distance from the visible boundaries of the screen.
Fixes #1 