### PR TITLE
Generate the player at gameroom start

### DIFF
--- a/objects/obj_player/obj_player.yy
+++ b/objects/obj_player/obj_player.yy
@@ -27,6 +27,7 @@
   ],
   "properties": [
     {"varType":3,"value":"False","rangeEnabled":false,"rangeMin":0.0,"rangeMax":10.0,"listItems":[],"multiselect":false,"filters":[],"resourceVersion":"1.0","name":"bullet_fired","tags":[],"resourceType":"GMObjectProperty",},
+    {"varType":1,"value":"1","rangeEnabled":false,"rangeMin":0.0,"rangeMax":10.0,"listItems":[],"multiselect":false,"filters":[],"resourceVersion":"1.0","name":"lives_left","tags":[],"resourceType":"GMObjectProperty",},
   ],
   "overriddenProperties": [],
   "parent": {

--- a/rooms/GameScreen/GameScreen.yy
+++ b/rooms/GameScreen/GameScreen.yy
@@ -14,7 +14,6 @@
   ],
   "layers": [
     {"instances":[
-        {"properties":[],"isDnd":false,"objectId":{"name":"obj_player","path":"objects/obj_player/obj_player.yy",},"inheritCode":false,"hasCreationCode":false,"colour":4294967295,"rotation":0.0,"scaleX":1.0,"scaleY":1.0,"imageIndex":0,"imageSpeed":1.0,"inheritedItemId":null,"frozen":false,"ignore":false,"inheritItemSettings":false,"x":640.0,"y":704.0,"resourceVersion":"1.0","name":"inst_3697A32F","tags":[],"resourceType":"GMRInstance",},
         {"properties":[],"isDnd":false,"objectId":{"name":"AlienController","path":"objects/AlienController/AlienController.yy",},"inheritCode":false,"hasCreationCode":false,"colour":4294967295,"rotation":0.0,"scaleX":1.0,"scaleY":1.0,"imageIndex":0,"imageSpeed":1.0,"inheritedItemId":null,"frozen":false,"ignore":false,"inheritItemSettings":false,"x":32.0,"y":800.0,"resourceVersion":"1.0","name":"inst_43F6FFA2","tags":[],"resourceType":"GMRInstance",},
         {"properties":[],"isDnd":false,"objectId":{"name":"obj_lose","path":"objects/obj_lose/obj_lose.yy",},"inheritCode":false,"hasCreationCode":false,"colour":4294967295,"rotation":0.0,"scaleX":1.0,"scaleY":1.0,"imageIndex":0,"imageSpeed":1.0,"inheritedItemId":null,"frozen":false,"ignore":false,"inheritItemSettings":false,"x":64.0,"y":800.0,"resourceVersion":"1.0","name":"inst_2A2F405E","tags":[],"resourceType":"GMRInstance",},
         {"properties":[],"isDnd":false,"objectId":{"name":"ctrl_game","path":"objects/ctrl_game/ctrl_game.yy",},"inheritCode":false,"hasCreationCode":false,"colour":4294967295,"rotation":0.0,"scaleX":1.0,"scaleY":1.0,"imageIndex":0,"imageSpeed":1.0,"inheritedItemId":null,"frozen":false,"ignore":false,"inheritItemSettings":false,"x":0.0,"y":800.0,"resourceVersion":"1.0","name":"inst_2FF5D4E","tags":[],"resourceType":"GMRInstance",},
@@ -25,7 +24,6 @@
   "creationCodeFile": "${project_dir}/rooms/GameScreen/RoomCreationCode.gml",
   "inheritCode": false,
   "instanceCreationOrder": [
-    {"name":"inst_3697A32F","path":"rooms/GameScreen/GameScreen.yy",},
     {"name":"inst_43F6FFA2","path":"rooms/GameScreen/GameScreen.yy",},
     {"name":"inst_2A2F405E","path":"rooms/GameScreen/GameScreen.yy",},
     {"name":"inst_2FF5D4E","path":"rooms/GameScreen/GameScreen.yy",},

--- a/rooms/GameScreen/RoomCreationCode.gml
+++ b/rooms/GameScreen/RoomCreationCode.gml
@@ -6,3 +6,5 @@ global.adjustedHeightStep = 32;
 global.gameOver = 0;
 
 generateAliens(192, 64, 5, 11);
+
+generatePlayer(3);

--- a/rooms/UnitTests/RoomCreationCode.gml
+++ b/rooms/UnitTests/RoomCreationCode.gml
@@ -1,5 +1,6 @@
 // Register all the test suites
 test_bullet_actions();
+test_level_generation_actions();
 
 // Run all the tests and auto-end the game
 test_run_all(true);

--- a/scripts/levelGenerationActions/levelGenerationActions.gml
+++ b/scripts/levelGenerationActions/levelGenerationActions.gml
@@ -10,3 +10,57 @@ function generateAliens(startX, startY, amountOfRows, amountOfColumns) {
 		yPos = yPos + 96;
 	}
 }
+
+function generatePlayer(lives_left) {
+	player = instance_create_layer(640, 704, "Instances", obj_player);
+	player.lives_left = lives_left;
+}
+
+
+#region UnitTests
+function test_level_generation_actions() {
+
+test_describe("generate_player_actions", function() {
+
+	test_after_each(function() {
+		instance_destroy(obj_player);
+	});
+
+	test_it("generates a player", function() {
+		// Act
+		generatePlayer(1337);
+
+		// Assert
+		assert_exists(obj_player);
+		assert_equal(1337, obj_player.lives_left, "Incorrect number of lives set on the player");
+	});
+
+});
+
+test_describe("generate_aliens_actions", function() {
+
+	test_after_each(function() {
+		instance_destroy(obj_alien);
+	});
+
+	test_it("generates an alien", function() {
+		// Act
+		generateAliens(0, 0, 1, 1);
+
+		// Assert
+		assert_exists(obj_alien);
+	});
+
+	test_it("generates multiple aliens", function() {
+		// Act
+		generateAliens(0, 0, 3, 3);
+
+		// Assert
+		assert_equal(9, instance_number(obj_alien), "Incorrect number of aliens generated");
+	});
+
+
+});
+}
+
+#endregion


### PR DESCRIPTION
This PR moves the player generation to the GameScreen creation code. This way, generating a player is testable, and creating new player can be done without restarting the room. Not sure if this is the way to go though - since this doesn not add  tangible benefit to application beyond the test...

I feel that we need to get rid of global state manipulation (like calling obj_player.bullet_fired from other places, or having a global.game_over) and put all that logic inside the player (or a gun object or whatever) and only manipulate that locally. If we work event-based, wou should be able to fire events in the test-suite and have better tesability that way...

Cool experimentation though - and quite easy to try multiple solutions for problems - did I mention... I <3 <3 <3 GameMaker? 

Soooo much immediate feedback :D
Did you notice the IDE warns you when:
- a variable/function is only refefrenced only once
- when you created a new var by accident  (color difference) because of a typo
- when you pass the wrong number of arguments to a function
