### PR TITLE
Add unittests for the eventbus

### DIFF
--- a/rooms/UnitTests/RoomCreationCode.gml
+++ b/rooms/UnitTests/RoomCreationCode.gml
@@ -1,5 +1,6 @@
 // Register all the test suites
 test_bullet_actions();
+test_eventbus();
 test_level_generation_actions();
 
 // Run all the tests and auto-end the game

--- a/rooms/UnitTests/RoomCreationCode.gml
+++ b/rooms/UnitTests/RoomCreationCode.gml
@@ -1,5 +1,6 @@
 // Register all the test suites
 test_bullet_actions();
+test_event_types();
 test_eventbus();
 test_level_generation_actions();
 

--- a/scripts/EventBus/EventBus.gml
+++ b/scripts/EventBus/EventBus.gml
@@ -10,6 +10,10 @@ function EventBus() constructor {
 		);
 	}
 	
+	/**
+	 * This method can be used to clear all subscribers for a certain event.
+	 * So be careful, when you unsubscribe you also delete other subscribers!
+	 */
 	unsubscribe = function(event) {
 		for (var index = 0; index < ds_list_size(events); index++) {
 			var evnt = ds_list_find_value(events, index);
@@ -30,3 +34,96 @@ function EventBus() constructor {
 }
 
 global.eventBus = new EventBus();
+
+#region UnitTests
+function test_eventbus() {
+
+test_describe("eventbus", function() {
+
+	test_it("It emits events", function() {
+		// Arrange
+		function TestEvent(_name) constructor {
+			name = _name;
+			subscriberHasBeenCalled = false;
+		}
+		var eventBus = new EventBus();
+		var eventThatisEmitted = new TestEvent(1);
+
+		// Act
+		eventBus.subscribe(1, function(event) {
+			event.subscriberHasBeenCalled = true;
+		});
+		eventBus.emit(eventThatisEmitted);
+
+		// Assert
+		assert_is_true(eventThatisEmitted.subscriberHasBeenCalled);
+	});
+
+	test_it("It only notifies subscribers", function() {
+		// Arrange
+		function TestEvent(_name) constructor {
+			name = _name;
+			subscriberHasBeenCalled = false;
+		}
+		var eventBus = new EventBus();
+		var eventThatisEmitted = new TestEvent(1);
+
+		// Act
+		eventBus.subscribe(2, function(event) {
+			event.subscriberHasBeenCalled = true;
+		});
+		eventBus.emit(eventThatisEmitted);
+
+		// Assert
+		assert_is_false(eventThatisEmitted.subscriberHasBeenCalled);
+	});
+
+	test_it("It un-subscribes", function() {
+		// Arrange
+		function TestEvent(_name) constructor {
+			name = _name;
+			subscriberHasBeenCalled = false;
+		}
+		var eventBus = new EventBus();
+		var eventThatisEmitted = new TestEvent(1);
+		eventBus.subscribe(1, function(event) {
+			event.subscriberHasBeenCalled = true;
+		});
+
+		// Act
+		eventBus.unsubscribe(1);
+		eventBus.emit(eventThatisEmitted);
+
+		// Assert
+		assert_is_false(eventThatisEmitted.subscriberHasBeenCalled);
+	});
+
+	test_it("It can fire for multiple subscribers on the same event", function() {
+		// Arrange
+		function TestEvent(_name) constructor {
+			name = _name;
+			subscriberHasBeenCalled = 0;
+		}
+		var eventBus = new EventBus();
+		var eventThatisEmitted = new TestEvent(1);
+
+		// Act
+		eventBus.subscribe(1, function(event) {
+			event.subscriberHasBeenCalled++;
+		});
+		eventBus.subscribe(1, function(event) {
+			event.subscriberHasBeenCalled++;
+		});
+		eventBus.subscribe(1, function(event) {
+			event.subscriberHasBeenCalled++;
+		});
+
+		eventBus.emit(eventThatisEmitted);
+
+		// Assert
+		assert_equal(3, eventThatisEmitted.subscriberHasBeenCalled);
+	});
+
+});
+}
+#endregion

--- a/scripts/event_types/event_types.gml
+++ b/scripts/event_types/event_types.gml
@@ -6,3 +6,21 @@ function BulletHitEvent(_bulletId) constructor {
 	name = eventTypes.BulletHitEvent;
 	bulletId = _bulletId;
 }
+
+#region UnitTests
+function test_event_types() {
+
+test_describe("event_types", function() {
+
+	test_it("is a BulletHitEvent", function() {
+		// Act
+		event = new BulletHitEvent(1337);
+
+		// Assert
+		assert_equal(eventTypes.BulletHitEvent, event.name);
+		assert_equal(1337, event.bulletId);
+	});
+
+});
+}
+#endregion


### PR DESCRIPTION
I took the liberty of writing some tests for the EventBus. I discovered that it is possible to have multiple subscribers for the same event, but that the unsubscribe will clear all those. I did not see an easy way out of that - perhaps it's not a problem. But maybe we need to remove unsubscribe completely? We don't have a case for it I believe... 